### PR TITLE
Updated auto configuration so that the correlation ID is not included…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <!-- Dependency versions -->
         <spring-boot.version>2.7.5</spring-boot.version>
         <spt-cid.version>2.0.11</spt-cid.version>
-        <spt-logging-spring.version>2.0.7</spt-logging-spring.version>
+        <spt-logging-spring.version>2.0.8</spt-logging-spring.version>
 
         <!-- Plugin versions -->
         <checkstyle-maven-plugin.version>3.1.2</checkstyle-maven-plugin.version>

--- a/spt-development-logging-spring-boot-autoconfigure/pom.xml
+++ b/spt-development-logging-spring-boot-autoconfigure/pom.xml
@@ -18,6 +18,10 @@
         <!-- Spring dependencies - version defined in spring-boot bom, import in parent dependencyManagement section -->
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>

--- a/spt-development-logging-spring-boot-autoconfigure/src/main/java/com/spt/development/logging/spring/boot/autoconfigure/LoggingSpringAutoConfiguration.java
+++ b/spt-development-logging-spring-boot-autoconfigure/src/main/java/com/spt/development/logging/spring/boot/autoconfigure/LoggingSpringAutoConfiguration.java
@@ -4,6 +4,7 @@ import com.spt.development.logging.spring.JmsListenerLogger;
 import com.spt.development.logging.spring.RepositoryLogger;
 import com.spt.development.logging.spring.RestControllerLogger;
 import com.spt.development.logging.spring.ServiceLogger;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -17,9 +18,22 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @AutoConfiguration
 public class LoggingSpringAutoConfiguration {
+    private final boolean mdcDisabled;
 
     /**
-     * Creates a vanilla {@link RestControllerLogger} (aspect) bean.
+     * Creates a new instance of the configuration bean with the spt.cid.mdc.disabled property.
+     *
+     * @param mdcDisabled a flag to determine whether the correlation ID can be expected to be in the MDC or not. If
+     *                    <code>false</code> then the loggers will explicitly include the current correlation ID in
+     *                    the log statements added by the aspects.
+     */
+    public LoggingSpringAutoConfiguration(@Value("${spt.cid.mdc.disabled:false}") final boolean mdcDisabled) {
+        this.mdcDisabled = mdcDisabled;
+    }
+
+    /**
+     * Creates a {@link RestControllerLogger} (aspect) bean. If the <code>spt.cid.mdc.disabled</code> property is set to
+     * <code>true</code>, the correlation ID will be included in the generated log statements.
      *
      * @return a new {@link RestControllerLogger} bean.
      */
@@ -27,11 +41,12 @@ public class LoggingSpringAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnClass({ RestController.class })
     public RestControllerLogger restControllerLogger() {
-        return new RestControllerLogger();
+        return new RestControllerLogger(mdcDisabled);
     }
 
     /**
-     * Creates a vanilla {@link JmsListenerLogger} (aspect) bean.
+     * Creates a {@link JmsListenerLogger} (aspect) bean. If the <code>spt.cid.mdc.disabled</code> property is set to
+     * <code>true</code>, the correlation ID will be included in the generated log statements.
      *
      * @return a new {@link JmsListenerLogger} bean.
      */
@@ -39,28 +54,30 @@ public class LoggingSpringAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnClass({ JmsListener.class })
     public JmsListenerLogger jmsListenerLogger() {
-        return new JmsListenerLogger();
+        return new JmsListenerLogger(mdcDisabled);
     }
 
     /**
-     * Creates a vanilla {@link ServiceLogger} (aspect) bean.
+     * Creates a {@link ServiceLogger} (aspect) bean. If the <code>spt.cid.mdc.disabled</code> property is set to
+     * <true>true</true>, the correlation ID will be included in the generated log statements.
      *
      * @return a new {@link ServiceLogger} bean.
      */
     @Bean
     @ConditionalOnMissingBean
     public ServiceLogger serviceLogger() {
-        return new ServiceLogger();
+        return new ServiceLogger(mdcDisabled);
     }
 
     /**
-     * Creates a vanilla {@link RepositoryLogger} (aspect) bean.
+     * Creates a vanilla {@link RepositoryLogger} (aspect) bean.  If the <code>spt.cid.mdc.disabled</code> property is
+     * set to <code>true</code>, the correlation ID will be included in the generated log statements.
      *
      * @return a new {@link RepositoryLogger} bean.
      */
     @Bean
     @ConditionalOnMissingBean
     public RepositoryLogger repositoryLogger() {
-        return new RepositoryLogger();
+        return new RepositoryLogger(mdcDisabled);
     }
 }


### PR DESCRIPTION
… in the generated log statements, if the spt.cid.mdc.disabled property is set to true